### PR TITLE
Added --partition argument and adjusted node & GPU name parsing to work on our cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ To print a summary of current activity:
 
 `slurm_gpustat`
 
+To print a summary of current activity on particular partitions, e.g. `debug` & `normal`:
+
+`slurm_gpustat -p debug,normal` or `slurm_gpustat --partition debug,normal`
+
 To start the logging dameon:
 
 `slurm_gpustat --action daemon-start`

--- a/slurm_gpustat/slurm_gpustat.py
+++ b/slurm_gpustat/slurm_gpustat.py
@@ -678,7 +678,7 @@ def main():
                               "provide statistics from historical data (provided that the"
                               "logging daemon has been running). 'daemon-start' and"
                               "'daemon-stop' will start and stop the daemon, resp."))
-    parser.add_argument("--partition", default=None,
+    parser.add_argument("-p", "--partition", default=None,
                         help="the partition/queue (or multiple, comma separated) of interest. "
                              "By default set to all available partitions.")
     parser.add_argument("--log_path",

--- a/slurm_gpustat/slurm_gpustat.py
+++ b/slurm_gpustat/slurm_gpustat.py
@@ -428,14 +428,16 @@ def parse_all_gpus(partition: (str, NoneType) = None,
         cmd += f" --partition={partition}"
     rows = parse_cmd(cmd)
     resources = defaultdict(list)
+
+    # Debug the regular expression below at
+    # https://regex101.com/r/RHYM8Z/3
+    p = re.compile(r'gpu:(?:(\w*):)?(\d*)(?:\(\S*\))?\s*')
+
     for row in rows:
         node_str, resource_strs = row.split("|")
         for resource_str in resource_strs.split(","):
             if not resource_str.startswith("gpu"):
                 continue
-            # Debug the regular expression below at
-            # https://regex101.com/r/RHYM8Z/3
-            p = re.compile(r'gpu:(?:(\w*):)?(\d*)(?:\(\S*\))?\s*')
             match = p.search(resource_str)
             gpu_type = match.group(1) if match.group(1) is not None else default_gpu_name
             # if the number of GPUs is not specified, we assume it is `default_gpus`

--- a/slurm_gpustat/slurm_gpustat.py
+++ b/slurm_gpustat/slurm_gpustat.py
@@ -496,7 +496,7 @@ def gpu_usage(resources: dict) -> dict:
     Returns:
         (dict): a summary of resources organised by user (and also by node name).
     """
-    cmd = "squeue -O tres-per-node,username,jobid,nodelist:30 --noheader"
+    cmd = "squeue -O tres-per-node,nodelist:30,username,jobid --noheader"
     detailed_job_cmd = "scontrol show jobid -dd %s"
     rows = parse_cmd(cmd)
     usage = defaultdict(dict)
@@ -505,7 +505,7 @@ def gpu_usage(resources: dict) -> dict:
         # ignore pending jobs
         if len(tokens) < 4 or not tokens[0].startswith("gpu"):
             continue
-        gpu_count_str, user, jobid, node_str = tokens
+        gpu_count_str, node_str, user, jobid = tokens
         gpu_count_tokens = gpu_count_str.split(":")
         num_gpus = int(gpu_count_tokens[-1])
         if len(gpu_count_tokens) == 2:

--- a/slurm_gpustat/slurm_gpustat.py
+++ b/slurm_gpustat/slurm_gpustat.py
@@ -423,7 +423,7 @@ def parse_all_gpus(partition: (str, NoneType) = None,
     Returns:
         a mapping between node names and a list of the GPUs that they have available.
     """
-    cmd = "sinfo -o '%1000N|%30G' --noheader"
+    cmd = "sinfo -o '%1000N|%1000G' --noheader"
     if partition:
         cmd += f" --partition={partition}"
     rows = parse_cmd(cmd)
@@ -505,7 +505,7 @@ def summary(mode: str, resources: dict = None, states: dict = None):
 
 
 @beartype
-def gpu_usage(resources: dict) -> dict:
+def gpu_usage(resources: dict, partition: (str, NoneType) = None) -> dict:
     """Build a data structure of the cluster resource usage, organised by user.
 
     Args:
@@ -514,7 +514,9 @@ def gpu_usage(resources: dict) -> dict:
     Returns:
         (dict): a summary of resources organised by user (and also by node name).
     """
-    cmd = "squeue -O tres-per-node,nodelist:100,username,jobid --noheader"
+    cmd = "squeue -O tres-per-node:100,nodelist:100,username:100,jobid:100 --noheader"
+    if partition:
+        cmd += f" --partition={partition}"
     detailed_job_cmd = "scontrol show jobid -dd %s"
     rows = parse_cmd(cmd)
     usage = defaultdict(dict)
@@ -562,7 +564,7 @@ def gpu_usage(resources: dict) -> dict:
 
 
 @beartype
-def in_use(resources: dict = None):
+def in_use(resources: dict = None, partition: (str, NoneType) = None):
     """Print a short summary of the resources that are currently used by each user.
 
     Args:
@@ -570,7 +572,7 @@ def in_use(resources: dict = None):
     """
     if not resources:
         resources = parse_all_gpus()
-    usage = gpu_usage(resources)
+    usage = gpu_usage(resources, partition=partition)
     aggregates = {}
     for user, subdict in usage.items():
         aggregates[user] = {}
@@ -663,7 +665,7 @@ def all_info(color: int, verbose: bool, partition: (str, NoneType) = None):
     for mode in ("up", "accessible"):
         summary(mode=mode, resources=resources, states=states)
         print(divider)
-    in_use(resources)
+    in_use(resources, partition=partition)
     print(divider)
     available(resources=resources, states=states, verbose=verbose)
     print(divider)

--- a/slurm_gpustat/slurm_gpustat.py
+++ b/slurm_gpustat/slurm_gpustat.py
@@ -547,9 +547,9 @@ def gpu_usage(resources: dict, partition: (str, NoneType) = None) -> dict:
             node_gpu_types = [x["type"] for x in resources[node_name]]
             if gpu_type is None:
                 if len(node_gpu_types) != 1:
-                    gpu_type = random.choice(node_gpu_types)
+                    gpu_type = sorted(resources[node_name], key=lambda k: k['count'], reverse=True)[0]['type']
                     msg = (f"cannot determine node gpu type for {user} on {node_name}"
-                           f" (guesssing {gpu_type})")
+                           f" (guessing {gpu_type})")
                     print(f"WARNING >>> {msg}")
                 else:
                     gpu_type = node_gpu_types[0]

--- a/slurm_gpustat/slurm_gpustat.py
+++ b/slurm_gpustat/slurm_gpustat.py
@@ -496,7 +496,7 @@ def gpu_usage(resources: dict) -> dict:
     Returns:
         (dict): a summary of resources organised by user (and also by node name).
     """
-    cmd = "squeue -O tres-per-node,nodelist:30,username,jobid --noheader"
+    cmd = "squeue -O tres-per-node,nodelist:100,username,jobid --noheader"
     detailed_job_cmd = "scontrol show jobid -dd %s"
     rows = parse_cmd(cmd)
     usage = defaultdict(dict)


### PR DESCRIPTION
By default 30 chars were too short to print some of our node names, increased the limit.

Some of our GPUs had weird names, changed the way it's parsed to a regexp, added examples of some weird outputs I got on some nodes to the following website where people contributing can keep iterating on the regexp used to cover other weird strings they encounter.
https://regex101.com/r/RHYM8Z/3